### PR TITLE
Update alexaSmartHomeV2.js

### DIFF
--- a/lib/alexaSmartHomeV2.js
+++ b/lib/alexaSmartHomeV2.js
@@ -220,7 +220,7 @@ function AlexaSH2(adapter) {
                     friendlyNames.splice(i, 1);
                 } else {
                     // friendlyName may not be longer than 128
-                    friendlyNames[i] = friendlyNames[i].substring(0, 128).replace(/[^a-zA-Z0-9äÄüÜöÖß]+/g, ' ');
+                    friendlyNames[i] = friendlyNames[i].substring(0, 128).replace(/[^a-zA-Z0-9äÄüÜöÖß.]+/g, ' ');
                 }
             }
 


### PR DESCRIPTION
Support of '.' in the friendlyName to support single characters in alexa speech requests.
I am not sure if this changes have any side effects. But I test it since a few days and it seems to work.