### PR TITLE
Support block-scoped declarations and basic type-checking

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ node_modules
 .ideatest
 .travis.yml
 appveyor.yml
+tsconfig.json

--- a/lib/alexaCustom.js
+++ b/lib/alexaCustom.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function AlexaCustom(adapter) {
     var lang          = 'de';
 

--- a/lib/alexaSmartHomeV2.js
+++ b/lib/alexaSmartHomeV2.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function AlexaSH2(adapter) {
 
     var smartDevices  = [];

--- a/lib/alexaSmartHomeV3.js
+++ b/lib/alexaSmartHomeV3.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function AlexaSH3(adapter) {
 
     var smartDevices  = [];

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var translate = require(__dirname + '/translate.js');
 
 var dictionary = [

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var translate = require(__dirname + '/translate.js');
 
 var dictionary = [

--- a/lib/rooms.js
+++ b/lib/rooms.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var translate = require(__dirname + '/translate.js');
 
 var dictionary = [

--- a/lib/translate.js
+++ b/lib/translate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function (dictionary, language, word) {
     var _word = (word || '').toString().toLowerCase();
     for (var r = 0; r < dictionary.length; r++) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var controllerDir;
 var appName;
 
@@ -10,6 +12,7 @@ function getAppName() {
 function getControllerDir(isInstall) {
     var fs = require('fs');
     // Find the js-controller location
+    /** @type {string | string[]} */
     var controllerDir = __dirname.replace(/\\/g, '/');
     controllerDir = controllerDir.split('/');
     if (controllerDir[controllerDir.length - 3] === 'adapter') {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "iobroker.socketio": ">=1.8.6"
   },
   "devDependencies": {
+    "@types/node": "^4.2.23",
     "gulp": "^3.9.1",
     "mocha": "^4.1.0",
     "chai": "^4.1.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,58 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": ["es6"],                             /* Specify library files to be included in the compilation:  */
+    "allowJs": true,                       /* Allow javascript files to be compiled. */
+    "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": false,                            /* Enable all strict type-checking options. */
+    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "include": [
+    "main.js",
+    "lib/**/*.js"
+  ]
+}


### PR DESCRIPTION
This PR basically does two things:
1. Set all script files to strict mode, so we can start using block-scoped declarations `let` / `const`.
2. Add basic `tsconfig.json` so VSCode does automatic type-checking using TypeScript. The typings for Node@4 are used by default

The next step would be using the block-scoped declarations and enabling a couple of the more strict rules, like `noImplicitAny` and especially `strictNullChecks`. The latter helps eliminate the null reference errors we've been seeing lately.
  