### PR TITLE
Use byON instead of byONs if we're not dealing with a group

### DIFF
--- a/lib/alexaSmartHomeV2.js
+++ b/lib/alexaSmartHomeV2.js
@@ -1335,7 +1335,9 @@ function AlexaSH2(adapter) {
 
                     var toggle = findRoleInChannel(channels[channel], 'level.dimmer');
                     if(toggle) {
-                        var byon = device.additionalApplianceDetails.byONs[toggle];
+                        var byon = (device.additionalApplianceDetails.group) ?
+                                        device.additionalApplianceDetails.byONs[toggle] :
+                                        device.additionalApplianceDetails.byON;
                         if(!byon || byon === '-') toggle = null;
                     }
                     if(!toggle) toggle = findRoleInChannel(channels[channel], 'switch');
@@ -1384,7 +1386,9 @@ function AlexaSH2(adapter) {
 
                     var toggle = findRoleInChannel(channels[channel], 'level.dimmer');
                     if (toggle) {
-                        var byon = device.additionalApplianceDetails.byONs[toggle];
+                        var byon = (device.additionalApplianceDetails.group) ?
+                                        device.additionalApplianceDetails.byONs[toggle] :
+                                        device.additionalApplianceDetails.byON;
                         if(!byon || byon === '-') toggle = null;
                     }
                     if (!toggle) toggle = findRoleInChannel(channels[channel], 'switch');


### PR DESCRIPTION
This fixes ioBroker/ioBroker.cloud#43

Accessed byONs even for non grouped Devices.
Now we're checking if we're a group before actually doing that.