### PR TITLE
More fixes

### DIFF
--- a/admin/actions.js
+++ b/admin/actions.js
@@ -13,9 +13,10 @@ function getActions(obj) {
         }
     } else {
         if (type === 'number') {
-            if (obj.common.unit === 'C' || obj.common.unit === 'C°' || obj.common.unit === '°C' ||
+            if ((obj.common.unit === 'C' || obj.common.unit === 'C°' || obj.common.unit === '°C' ||
                 obj.common.unit === 'F' || obj.common.unit === 'F°' || obj.common.unit === '°F' ||
-                obj.common.unit === 'K' || obj.common.unit === 'K°' || obj.common.unit === '°K') {
+                obj.common.unit === 'K' || obj.common.unit === 'K°' || obj.common.unit === '°K')
+                && obj.common.role !== "level.color.temperature") {
                 actions = ['setTargetTemperature', 'incrementTargetTemperature', 'decrementTargetTemperature', 'getTargetTemperature'];
                 type = '';
             } else if (obj.common.role === 'level.color.hue') {

--- a/lib/alexaSmartHomeV2.js
+++ b/lib/alexaSmartHomeV2.js
@@ -1092,6 +1092,7 @@ function AlexaSH2(adapter) {
 
             switch (friendlyUnit) {
                 case 'kelvin': {
+                    delta = delta * -1;
                     if (obj.common.min != null) minValue = parseFloat(obj.common.min);
                     if (obj.common.max != null) maxValue = parseFloat(obj.common.max);
                     break;

--- a/lib/alexaSmartHomeV2.js
+++ b/lib/alexaSmartHomeV2.js
@@ -308,7 +308,7 @@ function AlexaSH2(adapter) {
                     friendlyName:		 friendlyNames[n],
                     friendlyDescription: friendlyDescription,
                     isReachable:         true,
-                    actions:             actions,
+                    actions:             JSON.parse(JSON.stringify(actions)),
                     additionalApplianceDetails: {
                         id:            id.substring(0, 1024),
                         role:          states[id].common.role,
@@ -381,7 +381,7 @@ function AlexaSH2(adapter) {
                             friendlyName:		 friendlyNames[n],
                             friendlyDescription: words['Group'][lang] + ' ' + friendlyNames[n],
                             isReachable:         true,
-                            actions:             actions,
+                            actions:             JSON.parse(JSON.stringify(actions)),
                             additionalApplianceDetails: {
                                 group: true,
                                 channels:   {},

--- a/lib/alexaSmartHomeV2.js
+++ b/lib/alexaSmartHomeV2.js
@@ -1033,9 +1033,8 @@ function AlexaSH2(adapter) {
                 // The internal representation is in mired
                 value = 1e6 / value;
 
-                var minM = Math.round(1e6 / minK);
-                var maxM = Math.round(1e6 / maxK);
-              
+                let minM = Math.round(1e6 / maxK);
+                let maxM = Math.round(1e6 / minK);
                 if (friendlyUnit === 'mired') {
                     // respect the defined min/max
                     if (obj.common.min != null) minM = parseFloat(obj.common.min);
@@ -1098,8 +1097,8 @@ function AlexaSH2(adapter) {
                     break;
                 }
                 case 'mired': {
-                    minValue = Math.round(1e6 / minValue);
-                    maxValue = Math.round(1e6 / maxValue);
+                    minValue = Math.round(1e6 / maxValue);
+                    maxValue = Math.round(1e6 / minValue);
                     if (obj.common.min != null) minValue = parseFloat(obj.common.min);
                     if (obj.common.max != null) maxValue = parseFloat(obj.common.max);
                     break;
@@ -1126,8 +1125,8 @@ function AlexaSH2(adapter) {
                         // convert value back to Kelvin for reporting
                         if (friendlyUnit === 'percent') {
                             // back to mired
-                            const minM = 1e6 / minK;
-                            const maxM = 1e6 / maxK;
+                            const minM = 1e6 / maxK;
+                            const maxM = 1e6 / minK;
                             value = minM + value / 100 * (maxM - minM);
                         }
                         if (friendlyUnit === 'mired' || friendlyUnit === 'percent') {

--- a/lib/alexaSmartHomeV2.js
+++ b/lib/alexaSmartHomeV2.js
@@ -300,7 +300,7 @@ function AlexaSH2(adapter) {
 
             for (let n = 0; n < friendlyNames.length; n++) {
                 let obj = {
-                    applianceId:		 friendlyNames[n].replace(/[^a-zA-Z0-9_=#;:?@&-]+/g, '_'),
+                    applianceId:		 friendlyNames[n].replace(/[^a-zA-Zа-яА-ЯЁёßüöäÜÖÄ0-9_=#;:?@&-]+/g, '_'),
                     applianceTypes: [],
                     manufacturerName:	 'ioBroker',
                     modelName:		     (states[id].common.name || words['No name'][lang]).substring(0, 128),

--- a/lib/alexaSmartHomeV2.js
+++ b/lib/alexaSmartHomeV2.js
@@ -300,7 +300,7 @@ function AlexaSH2(adapter) {
 
             for (let n = 0; n < friendlyNames.length; n++) {
                 let obj = {
-                    applianceId:		 applianceId + (friendlyNames.length > 1 ? '_' + n : ''),
+                    applianceId:		 friendlyNames[n].replace(/[^a-zA-Z0-9_=#;:?@&-]+/g, '_'),
                     applianceTypes: [],
                     manufacturerName:	 'ioBroker',
                     modelName:		     (states[id].common.name || words['No name'][lang]).substring(0, 128),


### PR DESCRIPTION
Hi!

This fixes a few things:
- Controlling Kelvin via delta ("Make ... warmer"...). Delta (make warmer, make colder) did not work for kelvin as it needs to use a reversed delta.  I noticed that as I wrote my own Nanoleaf adapter which uses Kelvin for color temperature. Now controlling Color Temperature works for Nanoleaf (Kelvin), Hue (mired) and a fake percentage endpoint at the same time. 

- Revert https://github.com/ioBroker/ioBroker.cloud/pull/54 as it was faulty

- At some very strange times Actions are calculated wrong as it seems to fill the old action array resulting in features for a device which that device doesn't actually support. Now it uses a copy of actions to manipulate.

- Don't use Temperature actions for endpoints with "level.color.temperature" as we handle that seperatly. Otherwise it will be wrongly detected as Temperature controller and "Make ... warmer" won't work, or will work wrong.

- Always use the friendlyName as ApplienceId. Sometimes I noticed that if the cloud adapter is asked for a device list by alexa while building the devices, it then returns the endpoint-id instead of the friendlyname as applianceId. Once finished and having more then one endpoint the group then has the friendlyname as appliance ID. Alexa however is trying to switch the endpoint-id instead of the friendlyname and that fails. This is fixed by asking alexa to recheck for device but for me it happend nearly daily. @GermanBluefox Would be great if you could give this a second check to make sure it really doesn't break anything. Is there a reason why single endpoints are treated differently at all?

