### PR TITLE
(BuZZy1337) fix blockly sendTo when no instance exists

### DIFF
--- a/admin/blockly.js
+++ b/admin/blockly.js
@@ -61,6 +61,11 @@ Blockly.Blocks['ifttt'] = {
                 if (m) {
                     var n = parseInt(m[1], 10);
                     options.push(['cloud.' + n, '.' + n]);
+                }                
+            }
+            if (options.length === 0) {
+                for (var u = 0; u <= 4; u++) {
+                    options.push(['cloud.' + u, '.' + u]);
                 }
             }
         } else {


### PR DESCRIPTION
When the Cloud adapter is installed, but no instance is created then the Blockly sendTo Selector is broken..
![screenshot - 19 09 2018 16_56_12](https://user-images.githubusercontent.com/6979405/45761920-82465e00-bc2d-11e8-96b2-fff5de8e1c79.png)

This PR is fixing it..
![screenshot - 19 09 2018 16_59_09](https://user-images.githubusercontent.com/6979405/45761927-8a9e9900-bc2d-11e8-9eb7-551a4a0c06c1.png)
